### PR TITLE
Tolerate missing md5sums in control part when reading from file

### DIFF
--- a/debpkgr/debpkg.py
+++ b/debpkgr/debpkg.py
@@ -259,7 +259,11 @@ class DebPkg(object):
         using keyword arguments.
         """
         debpkg = debfile.DebFile(filename=path)
-        md5sums = debpkg.md5sums(encoding='utf-8')
+        # existance of md5sums in control part is optional
+        try:
+            md5sums = debpkg.md5sums(encoding='utf-8')
+        except:
+            md5sums = None
         control = debpkg.control.debcontrol().copy()
         hashes = cls.make_hashes(path)
         control.update(kwargs)

--- a/debpkgr/debpkg.py
+++ b/debpkgr/debpkg.py
@@ -262,7 +262,8 @@ class DebPkg(object):
         # existance of md5sums in control part is optional
         try:
             md5sums = debpkg.md5sums(encoding='utf-8')
-        except:
+        except debfile.DebError as err:
+            log.warn('While processing %s: %s', path, err.args[0])
             md5sums = None
         control = debpkg.control.debcontrol().copy()
         hashes = cls.make_hashes(path)

--- a/tests/unit/pkg_test.py
+++ b/tests/unit/pkg_test.py
@@ -406,3 +406,10 @@ class PkgTest(base.BaseTestCase):
         Filename = "pool/comp/a_1.deb"
         dp = DebPkg.from_file("/dev/null", Filename=Filename)
         self.assertEquals(Filename, dp._c['Filename'])
+
+    @base.mock.patch("debpkgr.debpkg.debfile.DebFile")
+    def test_pkg_from_file_without_md5sums(self, _DebFile):
+        _DebFile.return_value.md5sums.side_effect = Exception('No md5sums')
+        dp = DebPkg.from_file("/dev/null")
+        _DebFile.return_value.md5sums.assert_called_once()
+        self.assertEqual(dp.md5sums, DebPkgMD5sums())


### PR DESCRIPTION
The file md5sums in the control part of a debian package is optional. So this representation should not fail if it is missing. For simplicity, I'm setting the corresponding variable to None, to represent the given package file as closely as possible.

An example of such a package can be found at
http://ftp2.de.debian.org/debian/pool/contrib/a/atari800/atari800_3.1.0-1_amd64.deb