### PR TITLE
List Packages in Release relative to Release

### DIFF
--- a/tests/functional/repo_test.py
+++ b/tests/functional/repo_test.py
@@ -111,7 +111,8 @@ class RepoTest(base.BaseTestCase):
         # Make sure we removed the .gz we have created
         self.assertFalse(os.path.exists(pkgs_file + '.gz'))
         # Make sure we can correctly write packages back
-        comp_arch_bin.write_Packages(self.new_repo_dir)
+        comp_arch_bin.write_packages(self.new_repo_dir, repo.metadata.release_dir(
+            self.new_repo_dir))
 
         self.assertEquals(sz - 1, os.stat(pkgs_file).st_size)
         self.assertNotEquals(inode, os.stat(pkgs_file).st_ino)


### PR DESCRIPTION
The Packages files in an apt Repository should be referenced relative
to the directory in which the Release file is found.

Signed-off-by: Matthias Dellweg <dellweg@atix.de>