### PR TITLE
Fix component property setter

### DIFF
--- a/debpkgr/aptrepo.py
+++ b/debpkgr/aptrepo.py
@@ -102,14 +102,14 @@ class AptRepoMeta(object):
     def components(self):
         return self.release.get('Components', '').split()
 
+    @components.setter
+    def components(self, values):
+        assert isinstance(values, list)
+        self.release['Components'] = ' '.join(values)
+
     @property
     def codename(self):
         return self.release.get('Codename')
-
-    @components.setter
-    def _set_components(self, values):
-        assert isinstance(values, list)
-        self.release['Components'] = ' '.join(values)
 
     def init_component_arch_binaries(self):
         self._component_arch_binaries = []


### PR DESCRIPTION
Trying to use the old `@components.property` setter causes the following error:

`AttributeError: can't set attribute`

This is now fixed. I also moved the component setter next to the corresponding getter, as with the other getters/setters.