### PR TITLE
Fix repo structure when there is more than one folder level between "/dists/" and "/Release"

### DIFF
--- a/debpkgr/aptrepo.py
+++ b/debpkgr/aptrepo.py
@@ -268,10 +268,8 @@ class AptRepoMeta(object):
             fobj = path_to_fobj[preferred_filename]
             caobj = self.get_component_arch_binary(component, arch)
             dl_meta = dict(fobj, component=component, architecture=arch)
-            dest = os.path.join(base_path, caobj.relative_path('Packages'))
-            # Remove trailing Packages, replace with the actual file name from
-            # upstream
-            dest = os.path.join(os.path.dirname(dest),
+            dest = os.path.join(base_path,
+                                caobj.relative_path(''),
                                 os.path.basename(preferred_filename))
             utils.makedirs(os.path.dirname(dest))
             dl_reqs.append(utils.DownloadRequest(

--- a/tests/functional/repo_test.py
+++ b/tests/functional/repo_test.py
@@ -35,6 +35,7 @@ class RepoTest(base.BaseTestCase):
         super(RepoTest, self).setUp()
         self.repo_name = u'test_repo_foo'
         self.repo_codename = u'stable'
+        self.repo_suite = u'suite'
         self.repo_component = u'main'
         self.repo_arches = u'i386 amd64'
         self.repo_description = u'Apt repository for Test Repo Foo'
@@ -81,6 +82,7 @@ class RepoTest(base.BaseTestCase):
 
         repo = create_repo(self.new_repo_dir, files,
                            codename=self.repo_codename,
+                           suite=self.repo_suite,
                            arches=self.repo_arches,
                            components=[self.repo_component],
                            desc=self.repo_description,
@@ -119,9 +121,11 @@ class RepoTest(base.BaseTestCase):
                     files.append(os.path.join(root, f))
         arch = 'amd64'
         codename = 'stable'
+        suite = 'suite'
         component = 'main'
         repometa = AptRepoMeta(
             codename=codename,
+            suite=suite,
             components=[component],
             architectures=[arch])
 
@@ -151,7 +155,7 @@ class RepoTest(base.BaseTestCase):
             release_822.get('Description'),
             expected_default_origin)
         # Test default for Suite
-        self.assertEqual(release_822.get('Suite'), codename)
+        self.assertEqual(release_822.get('Suite'), suite)
         # Test handling of Architectures
         self.assertEqual(release_822.get('Architectures'), arch)
         self.assertEqual(repo.metadata.architectures, [arch])


### PR DESCRIPTION
This pull request fixes a bug in python-debpackager where apt repositories are not structured correctly when a repository has more than one folder level between "/dists/" and the release file.

An example for such a repository is debian-security (see http://security.debian.org/debian-security/).
Here the path from "dists" to the release file is "dists/stretch/updates/Release" for example.
Until now, python-debpackager would build this path as "dists/stretch/Release" instead.

This pull request seeks to better align python-debpackager with the Debian repository format specification (see https://wiki.debian.org/DebianRepository/Format).