### PR TITLE
Name MD5sum field using consistent case

### DIFF
--- a/debpkgr/aptrepo.py
+++ b/debpkgr/aptrepo.py
@@ -130,7 +130,7 @@ class AptRepoMeta(object):
             meta=dict(component=component, architecture=architecture))
 
     def component_arch_binary_package_files_from_release(self):
-        digests = ['SHA256', 'SHA1', 'MD5Sum']
+        digests = ['SHA256', 'SHA1', 'MD5sum']
         ret = dict()
         for digest_name in digests:
             if digest_name not in self.release:


### PR DESCRIPTION
I just noticed there was a single MD5sum dict field spellt 'MD5Sum' with capital 'S'.
All other such fields are either spelled 'MD5sum' (as in Debian repository files), or 'md5sum' (snake case).

This PR seeks to fix this minor typo.